### PR TITLE
Configure automatic builds for all platforms via GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
             os-prefix: MacOS
             build-dir: mac
           - os: ubuntu-latest
-            os-prefix: Ubuntu
+            os-prefix: Linux
             build-dir: linux-unpacked
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,19 +35,19 @@ jobs:
         with:
           node-version: 14
 
-      - name: Install packages
+      - name: Install dependencies
         run: npm install
 
-      - name: Run predefined build process
+      - name: Make executables
         run: npm run make
 
-      - name: Create release assets
+      - name: Create zip archives
         uses: papeloto/action-zip@v1
         with:
           files: dist/${{ matrix.build-dir }}
           dest: dist/WebClient-${{ matrix.os-prefix }}.zip
 
-      - name: Publish release assets
+      - name: Publish new release
         uses: softprops/action-gh-release@v1
       #     # If the commit is tagged with a version (e.g. "v1.0.0"),
       #     # release the app after building

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,4 +30,4 @@ jobs:
           # If the commit is tagged with a version (e.g. "v1.0.0"),
           # release the app after building
           release: ${{ startsWith(github.ref, 'refs/tags/v') }}
-          args:
+          args: --config build.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,21 +49,7 @@ jobs:
 
       - name: Publish new release
         uses: softprops/action-gh-release@v1
-      #     # If the commit is tagged with a version (e.g. "v1.0.0"),
-      #     # release the app after building
-      #     release: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           files: dist/WebClient-${{ matrix.os-prefix }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Build/release Electron app
-      #   uses: samuelmeuli/action-electron-builder@v1
-      #   with:
-      #     # GitHub token, automatically provided to the action
-      #     # (No need to define this secret in the repo settings)
-      #     github_token: ${{ secrets.github_token }}
-
-      #     # If the commit is tagged with a version (e.g. "v1.0.0"),
-      #     # release the app after building
-      #     release: ${{ startsWith(github.ref, 'refs/tags/v') }}
-      #     args: --config build.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,30 @@
 # Copy/paste example from https://github.com/marketplace/actions/electron-builder-action
 name: Build/release
 
-on: push
+on:
+  push:
+    tags:
+      - 'v*.*.*'
 
 jobs:
   release:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      max-parallel: 6
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
+        include:
+          - os: windows-latest
+            os-prefix: Windows
+            build-dir: win-unpacked
+          - os: macos-latest
+            os-prefix: MacOS
+            build-dir: mac
+          - os: ubuntu-latest
+            os-prefix: Ubuntu
+            build-dir: linux-unpacked
 
     steps:
       - name: Check out Git repository
@@ -20,14 +35,35 @@ jobs:
         with:
           node-version: 14
 
-      - name: Build/release Electron app
-        uses: samuelmeuli/action-electron-builder@v1
-        with:
-          # GitHub token, automatically provided to the action
-          # (No need to define this secret in the repo settings)
-          github_token: ${{ secrets.github_token }}
+      - name: Install packages
+        run: npm install
 
-          # If the commit is tagged with a version (e.g. "v1.0.0"),
-          # release the app after building
-          release: ${{ startsWith(github.ref, 'refs/tags/v') }}
-          args: --config build.json
+      - name: Run predefined build process
+        run: npm run make
+
+      - name: Create release assets
+        uses: papeloto/action-zip@v1
+        with:
+          files: dist/${{ matrix.build-dir }}
+          dest: dist/WebClient-${{ matrix.os-prefix }}.zip
+
+      - name: Publish release assets
+        uses: softprops/action-gh-release@v1
+      #     # If the commit is tagged with a version (e.g. "v1.0.0"),
+      #     # release the app after building
+      #     release: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        with:
+          files: dist/WebClient-${{ matrix.os-prefix }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Build/release Electron app
+      #   uses: samuelmeuli/action-electron-builder@v1
+      #   with:
+      #     # GitHub token, automatically provided to the action
+      #     # (No need to define this secret in the repo settings)
+      #     github_token: ${{ secrets.github_token }}
+
+      #     # If the commit is tagged with a version (e.g. "v1.0.0"),
+      #     # release the app after building
+      #     release: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      #     args: --config build.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+# Copy/paste example from https://github.com/marketplace/actions/electron-builder-action
+name: Build/release
+
+on: push
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v1
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - name: Build/release Electron app
+        uses: samuelmeuli/action-electron-builder@v1
+        with:
+          # GitHub token, automatically provided to the action
+          # (No need to define this secret in the repo settings)
+          github_token: ${{ secrets.github_token }}
+
+          # If the commit is tagged with a version (e.g. "v1.0.0"),
+          # release the app after building
+          release: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          args:

--- a/Core/Classes/AddOn.js
+++ b/Core/Classes/AddOn.js
@@ -14,7 +14,7 @@ class AddOn {
 		if (addonName !== this.name) return;
 
 		C_EventSystem.unregisterEvent("ADDON_LOADED", this.name);
-		INFO(format("Addon %s was successfully loaded", this.name));
+		INFO(format("%s: Addon was successfully loaded", this.name));
 
 		if (!this.onLoad instanceof Function) return;
 		this.onLoad();

--- a/build.json
+++ b/build.json
@@ -1,11 +1,18 @@
 {
 	"appId": "RevivalEngine.WebClient",
 	"productName": "Revival WebClient",
+	"win": {
+		"target": ["portable"]
+		},
 	"mac": {
-		"category": "public.app-category.games"
+		"category": "public.app-category.games",
+		"icon": "icon_512x512.png",
+		"publish": null
 	},
 	"linux": {
-        "icon": "icon_512x512.png"
+        "icon": "icon_512x512.png",
+		"target": "tar.gz",
+		"publish": null
 	},
 	"nsis": {
 		"oneClick": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revival-webclient",
-	"version": "0.21.04",
+	"version": "0.21.061515",
 	"description": "Browser-based client capable of rendering networked multiplayer games using modern web technologies.",
 	"main": "main.js",
 	"homepage": "https://revivalengine.github.io/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "revival-webclient",
-	"version": "0.21.061515",
+	"version": "0.21.0616",
 	"description": "Browser-based client capable of rendering networked multiplayer games using modern web technologies.",
 	"main": "main.js",
 	"homepage": "https://revivalengine.github.io/",


### PR DESCRIPTION
Progress:

- [x] Set up GitHub actions workflow
- [x] Create executables for Windows, Ubuntu and Mac OS X
- [x] Upload new releases with those executables archived
- [x] Builds are released automatically on a tagged release