### PR TITLE
Add integration with jsdoc and document the public APIs

### DIFF
--- a/Core/APIs/C_Decoding.js
+++ b/Core/APIs/C_Decoding.js
@@ -1,3 +1,15 @@
+/**
+ * Provides facilities for decoding Resources.
+ * <p>
+ * Decoding is the process of parsing data from an incompatible input source, such as custom binary or proprietary formats, and storing in memory a representation that the client understands.
+ * </p>
+ * @see {@link Resource}
+ * @see {@link Decoder}
+ * @see [HOWTO: Working with custom file formats]{@link http://google.com}
+ * @see [HOWTO: Writing your own decoder]{@link http://google.com}
+ * @namespace C_Decoding
+ *
+ */
 const C_Decoding = {
 	registeredDecoders: {},
 	getDecoderForFile(filePath) {
@@ -57,3 +69,41 @@ const C_Decoding = {
 		return decodedResource;
 	},
 };
+    /**
+     * Attempts to deduce the type for a given file (based on its extension). Returns the Decoder registered to it, or undefined if none was found.
+     * @param {string} filePath Path to the file that is to be decoded
+     * @returns {Decoder|undefined} The Decoder registered for this file type, or undefined if none has been registered
+     */
+    /**
+     * Attempts to deduce the type for a given file (based on its extension) and returns it.
+     * <p>
+     * Note: This is a simple convenience method. It specifically does NOT analyze the file itself and is thus very lightweight.
+     * </p>
+     * @param {string} filePath Path to the file that is to be decoded
+     * @returns {string} The file extension, excluding the dot.
+     */
+    /**
+     * Returns whether or not a given file can (presumably) be decoded.
+     *
+     * <p>
+     * Note: Files are assumed to be decodable if a Decoder for the given file type is registered, but this isn't verified internally.
+     * </p>
+     * @param {string} filePath Path to the file that is to be decoded
+     * @returns {boolean} <code>true</code> if the file type can be decoded, and <code>false</code> otherwise
+     */
+    /**
+     * TODO
+     *
+     */
+    /**
+     * Attempts to decode a given file, loading it from disk first if necessary.
+     *
+     * @param {string} filePath Path to the file that is to be decoded
+     * @return {Resource} The decoded resource that should now be ready to use
+     */
+    /**
+     * Attempts to decode a Resource using a given Decoder.
+     * @param {Resource} resource The Resource that is to be decoded
+     * @param {Decoder} decoder The Decoder that is to be used for this Resource
+     * @return {Resource} The decoded resource that should now be ready to use
+     */

--- a/Core/Classes/Decoder.js
+++ b/Core/Classes/Decoder.js
@@ -1,3 +1,7 @@
+/**
+ * Decoding stuff is fun
+ * @see {@link Resource, @link C_Decoding}
+ */
 class Decoder {
 	constructor(fileType, decodingFunction) {
 		this.fileType = fileType;

--- a/Core/Classes/Resource.js
+++ b/Core/Classes/Resource.js
@@ -1,3 +1,7 @@
+/**
+ * Resources are an in-memory representation of binary data. This standardized format can be created by decoding files from disk or any other input stream that would otherwise be unusable.
+ * @see C_Decoding, Decoder
+ */
 class Resource {
 	constructor(resourceID, isCritical = false, resourceData = []) {
 		this.resourceID = resourceID;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,12 @@
 			"integrity": "sha512-GLyWIFBbGvpKPGo55JyRZAo4lVbnBiD52cKlw/0Vt+wnmKvWJkpZvsjVoaIolyBXDeAQKSicRtqFNPem9w0WYA==",
 			"dev": true
 		},
+		"@babel/parser": {
+			"version": "7.14.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+			"integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
+			"dev": true
+		},
 		"@develar/schema-utils": {
 			"version": "2.6.5",
 			"resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
@@ -641,6 +647,15 @@
 			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
 			"dev": true
 		},
+		"catharsis": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+			"integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.15"
+			}
+		},
 		"chalk": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -1196,6 +1211,12 @@
 				"once": "^1.4.0"
 			}
 		},
+		"entities": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+			"integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+			"dev": true
+		},
 		"env-paths": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -1690,6 +1711,57 @@
 				"argparse": "^2.0.1"
 			}
 		},
+		"js2xmlparser": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.1.tgz",
+			"integrity": "sha512-KrPTolcw6RocpYjdC7pL7v62e55q7qOMHvLX1UCLc5AAS8qeJ6nukarEJAF2KL2PZxlbGueEbINqZR2bDe/gUw==",
+			"dev": true,
+			"requires": {
+				"xmlcreate": "^2.0.3"
+			}
+		},
+		"jsdoc": {
+			"version": "3.6.7",
+			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.7.tgz",
+			"integrity": "sha512-sxKt7h0vzCd+3Y81Ey2qinupL6DpRSZJclS04ugHDNmRUXGzqicMJ6iwayhSA0S0DwwX30c5ozyUthr1QKF6uw==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.9.4",
+				"bluebird": "^3.7.2",
+				"catharsis": "^0.9.0",
+				"escape-string-regexp": "^2.0.0",
+				"js2xmlparser": "^4.0.1",
+				"klaw": "^3.0.0",
+				"markdown-it": "^10.0.0",
+				"markdown-it-anchor": "^5.2.7",
+				"marked": "^2.0.3",
+				"mkdirp": "^1.0.4",
+				"requizzle": "^0.2.3",
+				"strip-json-comments": "^3.1.0",
+				"taffydb": "2.6.2",
+				"underscore": "~1.13.1"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+					"dev": true
+				},
+				"strip-json-comments": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+					"dev": true
+				}
+			}
+		},
 		"json-buffer": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -1736,6 +1808,15 @@
 				"json-buffer": "3.0.0"
 			}
 		},
+		"klaw": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+			"integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.9"
+			}
+		},
 		"latest-version": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
@@ -1751,12 +1832,20 @@
 			"integrity": "sha512-u93kb2fPbIrfzBuLjZE+w+fJbUUMhNDXxNmMfaqNgpfQf1CO5ZSe2LfsnBqVAk7i/2NF48OSoRj+Xe2VT+lE8Q==",
 			"dev": true
 		},
+		"linkify-it": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+			"integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+			"dev": true,
+			"requires": {
+				"uc.micro": "^1.0.1"
+			}
+		},
 		"lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"lowercase-keys": {
 			"version": "1.0.1",
@@ -1782,6 +1871,48 @@
 				"semver": "^6.0.0"
 			}
 		},
+		"markdown-it": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+			"integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+			"dev": true,
+			"requires": {
+				"argparse": "^1.0.7",
+				"entities": "~2.0.0",
+				"linkify-it": "^2.0.0",
+				"mdurl": "^1.0.1",
+				"uc.micro": "^1.0.5"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"dev": true,
+					"requires": {
+						"sprintf-js": "~1.0.2"
+					}
+				},
+				"sprintf-js": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+					"dev": true
+				}
+			}
+		},
+		"markdown-it-anchor": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz",
+			"integrity": "sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==",
+			"dev": true
+		},
+		"marked": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-2.1.1.tgz",
+			"integrity": "sha512-5XFS69o9CzDpQDSpUYC+AN2xvq8yl1EGa5SG/GI1hP78/uTeo3PDfiDNmsUyiahpyhToDDJhQk7fNtJsga+KVw==",
+			"dev": true
+		},
 		"matcher": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -1791,6 +1922,12 @@
 			"requires": {
 				"escape-string-regexp": "^4.0.0"
 			}
+		},
+		"mdurl": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+			"dev": true
 		},
 		"mime": {
 			"version": "2.5.2",
@@ -2110,6 +2247,15 @@
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
 		},
+		"requizzle": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
+			"integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.14"
+			}
+		},
 		"resolve": {
 			"version": "1.20.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -2384,6 +2530,12 @@
 				"has-flag": "^4.0.0"
 			}
 		},
+		"taffydb": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+			"integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+			"dev": true
+		},
 		"temp-file": {
 			"version": "3.3.7",
 			"resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.3.7.tgz",
@@ -2448,6 +2600,18 @@
 			"requires": {
 				"is-typedarray": "^1.0.0"
 			}
+		},
+		"uc.micro": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+			"dev": true
+		},
+		"underscore": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+			"integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+			"dev": true
 		},
 		"unique-string": {
 			"version": "2.0.0",
@@ -2640,6 +2804,12 @@
 			"integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
 			"dev": true,
 			"optional": true
+		},
+		"xmlcreate": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.3.tgz",
+			"integrity": "sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==",
+			"dev": true
 		},
 		"xmldom": {
 			"version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 	},
 	"devDependencies": {
 		"electron": "11.1.1",
-		"electron-builder": "22.10.5"
+		"electron-builder": "22.10.5",
+		"jsdoc": "3.6.7"
 	},
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
### Goals

Please describe briefly the intended purpose of the change and the rationale behind it:

- [ ] Document the public APIs (see the linked issue for details)

### Roadmap

Please list the exact steps needed to implement the change here, in as much detail as you see fit:

- [x] Add jsdoc as development dependency
- [ ] Create npm script to generate the docs
- [ ] Add doc comments to all APIs and components, enums etc. (see linked issue)

### Testing

- [x] All components touched by this change are tested (via unit tests)
- [x] All public interfaces touched by this change are tested (via integration tests)
- [x] All interactions involving the systems affected by this change are tested (via system tests)

### Documentation

- [ ] Tutorials are updated where relevant (if an introduction is needed)
- [ ] HowTos are updated to account for this change
- [ ] Explanations are updated or created (for complex changes)
- [ ] API references are updated to reflect this change
