### PR TITLE
Fix failing CI tests on the GitHub Actions-provided Ubuntu VM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,14 @@ jobs:
       max-parallel: 6
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
-
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        include:
+          - os: windows-latest
+            ubuntu-workaround-prefix-string: ''
+          - os: macos-latest
+            ubuntu-workaround-prefix-string: ''
+          - os: ubuntu-latest
+            ubuntu-workaround-prefix-string: export DISPLAY=:45 && xvfb-run --server-num 45
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v1
@@ -26,4 +32,4 @@ jobs:
         run: npm install --also=dev
 
       - name: Run automated tests
-        run: npm test
+        run: ${{ matrix.ubuntu-workaround-prefix-string }} npm test


### PR DESCRIPTION
### Goals

Please describe briefly the intended purpose of the change and the rationale behind it:

- [x] Allow us to run tests on the ``ubuntu-latest`` runner instead of just mac and windows

### Roadmap

Please list the exact steps needed to implement the change here, in as much detail as you see fit:

- [x] Fix build configuration to work around the DISPLAY issue uncovered as part of the investigation

### Testing

- [x] All components touched by this change are tested (via unit tests)
- [x] All public interfaces touched by this change are tested (via integration tests)
- [x] All interactions involving the systems affected by this change are tested (via system tests)

### Documentation

- [x] Tutorials are updated where relevant (if an introduction is needed)
- [x] HowTos are updated to account for this change
- [x] Explanations are updated or created (for complex changes)
- [x] API references are updated to reflect this change
