### PR TITLE
Improve accuracy and usefulness of the "No TODOs" CI workflow 

### DIFF
--- a/.github/check-for-todos.sh
+++ b/.github/check-for-todos.sh
@@ -28,7 +28,7 @@ if [ $NUMBER_OF_COMMITTED_TODOS -ne 0 ]; then
 
 	echo "Processed git diff:"
 	echo ""
-	git diff origin/main HEAD | grep ^+ | grep --color=always 'TODO'
+	git diff origin/main HEAD | grep ^+ | grep --color=always 'TODO' -C3
 
 	exit 1
 fi
@@ -43,7 +43,7 @@ if [ $NUMBER_OF_COMMITTED_TBDS -ne 0 ]; then
 
 	echo "Processed git diff:"
 	echo ""
-	git diff origin/main HEAD | grep ^+ | grep --color=always 'TBD'
+	git diff origin/main HEAD | grep ^+ | grep --color=always 'TBD' -C3
 
 	exit 2
 fi
@@ -58,7 +58,7 @@ if [ $NUMBER_OF_COMMITTED_WIPS -ne 0 ]; then
 
 	echo "Processed git diff:"
 	echo ""
-	git diff origin/main HEAD | grep ^+ | grep --color=always 'WIP'
+	git diff origin/main HEAD | grep ^+ | grep --color=always 'WIP' -C3
 
 	exit 3
 fi
@@ -73,7 +73,7 @@ if [ $NUMBER_OF_COMMITTED_FIXMES -ne 0 ]; then
 
 	echo "Processed git diff:"
 	echo ""
-	git diff origin/main HEAD | grep ^+ | grep --color=always 'FIXME'
+	git diff origin/main HEAD | grep ^+ | grep --color=always 'FIXME' -C3
 
 	exit 4
 fi
@@ -88,7 +88,7 @@ if [ $NUMBER_OF_COMMITTED_HACKS -ne 0 ]; then
 
 	echo "Processed git diff:"
 	echo ""
-	git diff origin/main HEAD | grep ^+ | grep --color=always 'HACK'
+	git diff origin/main HEAD | grep ^+ | grep --color=always 'HACK' -C3
 
 	exit 5
 fi

--- a/.github/check-for-todos.sh
+++ b/.github/check-for-todos.sh
@@ -4,11 +4,11 @@ echo "Checking for temporary comments..."
 
 echo ""
 
-NUMBER_OF_COMMITTED_TODOS=$(git diff HEAD origin/main | grep -o 'TODO' | wc -l)
-NUMBER_OF_COMMITTED_TBDS=$(git diff HEAD origin/main | grep -o 'TBD' | wc -l)
-NUMBER_OF_COMMITTED_WIPS=$(git diff HEAD origin/main | grep -o 'WIP' | wc -l)
-NUMBER_OF_COMMITTED_FIXMES=$(git diff HEAD origin/main | grep -o 'FIXME' | wc -l)
-NUMBER_OF_COMMITTED_HACKS=$(git diff HEAD origin/main | grep -o 'HACK' | wc -l)
+NUMBER_OF_COMMITTED_TODOS=$(git diff origin/main HEAD | grep ^+ | grep -o 'TODO' | wc -l)
+NUMBER_OF_COMMITTED_TBDS=$(git diff origin/main HEAD | grep ^+ | grep -o 'TBD' | wc -l)
+NUMBER_OF_COMMITTED_WIPS=$(git diff origin/main HEAD | grep ^+ | grep -o 'WIP' | wc -l)
+NUMBER_OF_COMMITTED_FIXMES=$(git diff origin/main HEAD | grep ^+ | grep -o 'FIXME' | wc -l)
+NUMBER_OF_COMMITTED_HACKS=$(git diff origin/main HEAD | grep ^+ | grep -o 'HACK' | wc -l)
 
 echo "Committed TODOs: $NUMBER_OF_COMMITTED_TODOS"
 echo "Committed TBDs: $NUMBER_OF_COMMITTED_TBDS"
@@ -28,7 +28,7 @@ if [ $NUMBER_OF_COMMITTED_TODOS -ne 0 ]; then
 
 	echo "Processed git diff:"
 	echo ""
-	git diff HEAD origin/main | grep --color=always 'TODO'
+	git diff origin/main HEAD | grep ^+ | grep --color=always 'TODO'
 
 	exit 1
 fi
@@ -43,7 +43,7 @@ if [ $NUMBER_OF_COMMITTED_TBDS -ne 0 ]; then
 
 	echo "Processed git diff:"
 	echo ""
-	git diff HEAD origin/main | grep --color=always 'TBD'
+	git diff origin/main HEAD | grep ^+ | grep --color=always 'TBD'
 
 	exit 2
 fi
@@ -58,7 +58,7 @@ if [ $NUMBER_OF_COMMITTED_WIPS -ne 0 ]; then
 
 	echo "Processed git diff:"
 	echo ""
-	git diff HEAD origin/main | grep --color=always 'WIP'
+	git diff origin/main HEAD | grep ^+ | grep --color=always 'WIP'
 
 	exit 3
 fi
@@ -73,7 +73,7 @@ if [ $NUMBER_OF_COMMITTED_FIXMES -ne 0 ]; then
 
 	echo "Processed git diff:"
 	echo ""
-	git diff HEAD origin/main | grep --color=always 'FIXME'
+	git diff origin/main HEAD | grep ^+ | grep --color=always 'FIXME'
 
 	exit 4
 fi
@@ -88,7 +88,7 @@ if [ $NUMBER_OF_COMMITTED_HACKS -ne 0 ]; then
 
 	echo "Processed git diff:"
 	echo ""
-	git diff HEAD origin/main | grep --color=always 'HACK'
+	git diff origin/main HEAD | grep ^+ | grep --color=always 'HACK'
 
 	exit 5
 fi

--- a/.github/check-for-todos.sh
+++ b/.github/check-for-todos.sh
@@ -4,11 +4,11 @@ echo "Checking for temporary comments..."
 
 echo ""
 
-NUMBER_OF_COMMITTED_TODOS=$(git diff origin/main HEAD | grep ^+ | grep -o 'TODO' | wc -l)
-NUMBER_OF_COMMITTED_TBDS=$(git diff origin/main HEAD | grep ^+ | grep -o 'TBD' | wc -l)
-NUMBER_OF_COMMITTED_WIPS=$(git diff origin/main HEAD | grep ^+ | grep -o 'WIP' | wc -l)
-NUMBER_OF_COMMITTED_FIXMES=$(git diff origin/main HEAD | grep ^+ | grep -o 'FIXME' | wc -l)
-NUMBER_OF_COMMITTED_HACKS=$(git diff origin/main HEAD | grep ^+ | grep -o 'HACK' | wc -l)
+NUMBER_OF_COMMITTED_TODOS=$(git diff origin/main HEAD ':(exclude).github/check-for-todos.sh' | grep ^+ | grep -o 'TODO' | wc -l)
+NUMBER_OF_COMMITTED_TBDS=$(git diff origin/main HEAD ':(exclude).github/check-for-todos.sh' | grep ^+ | grep -o 'TBD' | wc -l)
+NUMBER_OF_COMMITTED_WIPS=$(git diff origin/main HEAD ':(exclude).github/check-for-todos.sh' | grep ^+ | grep -o 'WIP' | wc -l)
+NUMBER_OF_COMMITTED_FIXMES=$(git diff origin/main HEAD ':(exclude).github/check-for-todos.sh' | grep ^+ | grep -o 'FIXME' | wc -l)
+NUMBER_OF_COMMITTED_HACKS=$(git diff origin/main HEAD ':(exclude).github/check-for-todos.sh' | grep ^+ | grep -o 'HACK' | wc -l)
 
 echo "Committed TODOs: $NUMBER_OF_COMMITTED_TODOS"
 echo "Committed TBDs: $NUMBER_OF_COMMITTED_TBDS"
@@ -28,7 +28,7 @@ if [ $NUMBER_OF_COMMITTED_TODOS -ne 0 ]; then
 
 	echo "Processed git diff:"
 	echo ""
-	git diff origin/main HEAD | grep ^+ | grep --color=always 'TODO' -C3
+	git diff origin/main HEAD ':(exclude).github/check-for-todos.sh' | grep ^+ | grep --color=always 'TODO' -C3
 
 	exit 1
 fi
@@ -43,7 +43,7 @@ if [ $NUMBER_OF_COMMITTED_TBDS -ne 0 ]; then
 
 	echo "Processed git diff:"
 	echo ""
-	git diff origin/main HEAD | grep ^+ | grep --color=always 'TBD' -C3
+	git diff origin/main HEAD ':(exclude).github/check-for-todos.sh' | grep ^+ | grep --color=always 'TBD' -C3
 
 	exit 2
 fi
@@ -58,7 +58,7 @@ if [ $NUMBER_OF_COMMITTED_WIPS -ne 0 ]; then
 
 	echo "Processed git diff:"
 	echo ""
-	git diff origin/main HEAD | grep ^+ | grep --color=always 'WIP' -C3
+	git diff origin/main HEAD ':(exclude).github/check-for-todos.sh' | grep ^+ | grep --color=always 'WIP' -C3
 
 	exit 3
 fi
@@ -73,7 +73,7 @@ if [ $NUMBER_OF_COMMITTED_FIXMES -ne 0 ]; then
 
 	echo "Processed git diff:"
 	echo ""
-	git diff origin/main HEAD | grep ^+ | grep --color=always 'FIXME' -C3
+	git diff origin/main HEAD ':(exclude).github/check-for-todos.sh' | grep ^+ | grep --color=always 'FIXME' -C3
 
 	exit 4
 fi
@@ -88,7 +88,7 @@ if [ $NUMBER_OF_COMMITTED_HACKS -ne 0 ]; then
 
 	echo "Processed git diff:"
 	echo ""
-	git diff origin/main HEAD | grep ^+ | grep --color=always 'HACK' -C3
+	git diff origin/main HEAD ':(exclude).github/check-for-todos.sh' | grep ^+ | grep --color=always 'HACK' -C3
 
 	exit 5
 fi


### PR DESCRIPTION
There were some issues that I stumbled upon while wrapping up #130 , which should now be resolved:

* The workflow no longer fails if changes to the TODO checking script itself are made (silly)
* It also ignores removed lines, and only indicates failure when newly-added "temporary" comments are detected
* Optional improvement: It now displays more context to make troubleshooting the errors easier