### PR TITLE
CI: Eliminate duplicate workflow runs from Pull Requests

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -2,14 +2,15 @@
 name: Build and Release
 
 on:
+  pull_request:
+    paths-ignore:
+      - "README.md"
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-  create:
-    # Any branch or tag
+    paths-ignore:
+      - "README.md"
 
 jobs:
   build:

--- a/.github/workflows/check-format-via-prettier.yml
+++ b/.github/workflows/check-format-via-prettier.yml
@@ -1,7 +1,15 @@
 name: Formatting
 
 on:
+  pull_request:
+    paths-ignore:
+      - "README.md"
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
+    branches:
+      - main
+    paths-ignore:
+      - "README.md"
 
 jobs:
   lint:

--- a/.github/workflows/detect-temporary-comments.yml
+++ b/.github/workflows/detect-temporary-comments.yml
@@ -1,7 +1,15 @@
 name: No TODOs
 
 on:
+  pull_request:
+    paths-ignore:
+      - "README.md"
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
+    branches:
+      - main
+    paths-ignore:
+      - "README.md"
 
 jobs:
   lint:

--- a/.github/workflows/run-automated-tests.yml
+++ b/.github/workflows/run-automated-tests.yml
@@ -1,7 +1,15 @@
 name: Automated Testing
 
 on:
+  pull_request:
+    paths-ignore:
+      - "README.md"
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
+    branches:
+      - main
+    paths-ignore:
+      - "README.md"
 
 jobs:
   test:

--- a/.github/workflows/static-analysis-via-eslint.yml
+++ b/.github/workflows/static-analysis-via-eslint.yml
@@ -1,7 +1,15 @@
 name: Static Analysis
 
 on:
+  pull_request:
+    paths-ignore:
+      - "README.md"
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
+    branches:
+      - main
+    paths-ignore:
+      - "README.md"
 
 jobs:
   lint:


### PR DESCRIPTION
I noticed this as part of #130  and #142 , even if it's not really related to the changes.

---

The previous configuration would trigger two runs when changes were made to PRs. That's hugely wasteful, increases the time-to-feedback, and simply not useful in the slightest.

Update: It actually only triggers the duplicate runs when the PRs are merged (on the merge commit), but the same reasoning holds.