### PR TITLE
CI: Fix a rare error with electron-mocha on Linux systems

### DIFF
--- a/.github/workflows/run-automated-tests.yml
+++ b/.github/workflows/run-automated-tests.yml
@@ -18,7 +18,7 @@ jobs:
           - os: macos-latest
             ubuntu-workaround-prefix-string: ""
           - os: ubuntu-latest
-            ubuntu-workaround-prefix-string: export DISPLAY=:45 && xvfb-run --server-num 45
+            ubuntu-workaround-prefix-string: export DISPLAY=:45 && xvfb-run --auto-servernum --server-num 45
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v1


### PR DESCRIPTION
Looks like sometimes the output can't be routed to the xvfb server and it just fails the CI, but only on Linux (since Windows doesn't need this workaround in the first place).

According to the wise people of StackOverflow, this should prevent that error by letting it choose a free slot automatically if the selected one is unavailable.

Will it work? I have no idea. I guess we'll see if there ever is another failed CI run with this error...

---

Edit: More info here https://stackoverflow.com/questions/16726227/xvfb-failed-start-error/25610678

Example of a failed CI run: https://github.com/RevivalEngine/WebClient/runs/4237359998?check_suite_focus=true

Screenshot:

![image](https://user-images.githubusercontent.com/16489133/142193542-35d5152a-939c-4a14-b714-48d92793c8d8.png)
