### PR TITLE
Add some basic validation builtins

### DIFF
--- a/Config/eslint.json
+++ b/Config/eslint.json
@@ -88,6 +88,8 @@
 		"Table": "writable",
 		"TerrainMap": "writable",
 		"UIParent": "writable",
+		"validateString": "writable",
+		"validateNumber": "writable",
 		"Vector3D": "writable",
 		"ViewportContainer": "writable",
 		"WebClient": "writable",

--- a/Core/APIs/C_Validation.js
+++ b/Core/APIs/C_Validation.js
@@ -1,5 +1,6 @@
 var format = require("util").format;
 
+// @deprecated Validators should be global builtins, since APIs are intended to provide high-level engine functionality
 const C_Validation = {
 	// TODO: Move to a proper schema file
 	addonMetadata: {

--- a/Core/Builtins/Validation.js
+++ b/Core/Builtins/Validation.js
@@ -1,0 +1,12 @@
+function validateString(objectToTypecheck, errorMessage) {
+	// In JavaScript, Strings can be objects or literals. Perhaps they could also be flying dinosaurs?
+	const isString = typeof objectToTypecheck === "string" || objectToTypecheck instanceof String;
+	if (!isString) throw new TypeError(errorMessage);
+}
+
+function validateNumber(objectToTypecheck, errorMessage) {
+	const isNumber = typeof objectToTypecheck === "number" || objectToTypecheck instanceof Number;
+	// NaN is technically a "number" value, but can't be checked normally, because JavaScript is awesome like that
+	const isNaN = objectToTypecheck !== objectToTypecheck; // isNaN() should also work, except for when it doesn't...
+	if (!isNumber || isNaN) throw new TypeError(errorMessage);
+}

--- a/Tests/Builtins/Validators.js
+++ b/Tests/Builtins/Validators.js
@@ -1,0 +1,9 @@
+describe("Validators", () => {
+	let exportedApiSurface = ["validateString", "validateNumber"];
+
+	exportedApiSurface.forEach((namedExport) => {
+		it("should export function " + namedExport, () => {
+			assertEquals(typeof window[namedExport], "function");
+		});
+	});
+});

--- a/Tests/run-renderer-tests.js
+++ b/Tests/run-renderer-tests.js
@@ -1,6 +1,6 @@
 const testSuites = {
 	SharedConstants: ["SharedConstants/Paths.js"],
-	Builtins: ["Builtins/Assertions.js", "Builtins/LocalCacheTests.js"],
+	Builtins: ["Builtins/Assertions.js", "Builtins/LocalCacheTests.js", "Builtins/Validators.js"],
 	C_Settings: [
 		"API/C_Settings/validate.js",
 		"API/C_Settings/validateDefaultSettings.js",

--- a/index.html
+++ b/index.html
@@ -140,4 +140,5 @@
 			StartWebClient();
 		</script>
 	</body>
+	<script src="Core/Builtins/Validation.js"></script>
 </html>


### PR DESCRIPTION
This should eventually replace the ``C_Validation`` API, since validation is a low-level (and cross-cutting) concern, not a high-level engine functionality.

I don't currently want to spend the time to streamline the API itself right now, as I'm still working on #130 ... so that'll have to be a separate issue.