### PR TITLE
Add toArrayBuffer() method to the Resource builtin

### DIFF
--- a/Core/Classes/Resource.js
+++ b/Core/Classes/Resource.js
@@ -24,4 +24,9 @@ class Resource {
 	isReady() {
 		return this.state === Enum.RESOURCE_STATE_READY;
 	}
+	toArrayBuffer() {
+		const newBuffer = new ArrayBuffer(this.data.byteLength);
+		new Uint8Array(newBuffer).set(new Uint8Array(this.data));
+		return newBuffer;
+	}
 }

--- a/Tests/Builtins/Resource.js
+++ b/Tests/Builtins/Resource.js
@@ -1,5 +1,13 @@
 describe("Resource", () => {
-	const resource = new Resource();
+	const data = new ArrayBuffer(12);
+
+	const originalBuffer = new DataView(data);
+	originalBuffer.setUint32(0, 42);
+	originalBuffer.setUint32(4, 43);
+	originalBuffer.setUint32(8, 44);
+
+	const resource = new Resource("resourceID", false, data);
+
 	it("should be exported into the global environment", () => {
 		assertEquals(resource.constructor.name, "Resource");
 	});
@@ -9,6 +17,32 @@ describe("Resource", () => {
 	exportedApiSurface.forEach((namedExport) => {
 		it("should export function " + namedExport, () => {
 			assertEquals(typeof resource[namedExport], "function");
+		});
+	});
+
+	describe("toArrayBuffer", () => {
+		const buffer = resource.toArrayBuffer();
+		it("should return an object of type ArrayBuffer", () => {
+			assertEquals(buffer.constructor.name, "ArrayBuffer");
+		});
+
+		it("should return a copy of the data stored in its internal buffer", () => {
+			const reader = new DataView(buffer);
+			assertEquals(reader.getUint32(0), originalBuffer.getUint32(0));
+			assertEquals(reader.getUint32(4), originalBuffer.getUint32(4));
+			assertEquals(reader.getUint32(8), originalBuffer.getUint32(8));
+		});
+
+		it("should return a copy of its internal buffer and not the original", () => {
+			// Since we can't directly check for equality with buffers, modify the copy to see if it affects the original
+			const copiedBuffer = new DataView(buffer);
+			copiedBuffer.setUint32(0, 123);
+			copiedBuffer.setUint32(4, 234);
+			copiedBuffer.setUint32(8, 567);
+
+			assertNotEquals(copiedBuffer.getUint32(0), originalBuffer.getUint32(0));
+			assertNotEquals(copiedBuffer.getUint32(4), originalBuffer.getUint32(4));
+			assertNotEquals(copiedBuffer.getUint32(8), originalBuffer.getUint32(8));
 		});
 	});
 });

--- a/Tests/Builtins/Resource.js
+++ b/Tests/Builtins/Resource.js
@@ -1,0 +1,14 @@
+describe("Resource", () => {
+	const resource = new Resource();
+	it("should be exported into the global environment", () => {
+		assertEquals(resource.constructor.name, "Resource");
+	});
+
+	let exportedApiSurface = ["isReady", "toArrayBuffer", "touch"];
+
+	exportedApiSurface.forEach((namedExport) => {
+		it("should export function " + namedExport, () => {
+			assertEquals(typeof resource[namedExport], "function");
+		});
+	});
+});

--- a/Tests/run-renderer-tests.js
+++ b/Tests/run-renderer-tests.js
@@ -5,6 +5,7 @@ const testSuites = {
 		"Builtins/LocalCacheTests.js",
 		"Builtins/Decoder.js",
 		"Builtins/UniqueID.js",
+		"Builtins/Resource.js",
 		"Builtins/Validators.js",
 	],
 	C_Settings: [


### PR DESCRIPTION
This allows using the internal buffer with non-idempotent operations, such as turning it into an AudioBuffer (WebAudio API).