### PR TITLE
CI: Use Node 16 for workflow runs to ensure compatibility

### DIFF
--- a/.github/workflows/run-automated-tests.yml
+++ b/.github/workflows/run-automated-tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Install development dependencies
         run: npm install --also=dev


### PR DESCRIPTION
The package.json format is now using version 16 and apparently npm can't deal with that when trying to install packages on the GitHub Actions runner.