### PR TITLE
Fix an error in the startup routines that would crash the client when no macro-cache is present on disk

### DIFF
--- a/Core/APIs/C_Macro.js
+++ b/Core/APIs/C_Macro.js
@@ -55,7 +55,11 @@ C_Macro.saveToDisk = function (macroID) {};
 C_Macro.restoreMacroCache = function () {
 	DEBUG("Reloading macro cache from disk");
 
-	const macroCache = C_FileSystem.readJSON(C_Settings.getValue("macroCachePath"));
+	const macroCachePath = C_Settings.getValue("macroCachePath");
+	// Basically the same as initialization, though this may need revisiting in the future
+	if (!C_FileSystem.fileExists(macroCachePath)) this.saveMacroCache();
+
+	const macroCache = C_FileSystem.readJSON(macroCachePath);
 	for (let macroID in macroCache) {
 		const macroInfo = macroCache[macroID];
 		DEBUG(format("Deserializing macro %s", macroID));

--- a/Core/Aliases.js
+++ b/Core/Aliases.js
@@ -2,6 +2,7 @@
 const NODE = {
 	FileSystem: require("fs"),
 	Assert: require("assert"),
+	path: require("path"),
 };
 
 // Dependencies imported via their NPM package

--- a/Tests/API/Macro/restoreMacroCache.js
+++ b/Tests/API/Macro/restoreMacroCache.js
@@ -1,0 +1,20 @@
+describe("restoreMacroCache", () => {
+	let macroCachePath = null;
+	const invalidMacroCachePath = NODE.path.join(WEBCLIENT_TESTS_DIR, "does-not-exist.json");
+	before(() => {
+		macroCachePath = C_Settings.getValue("macroCachePath");
+	});
+
+	after(() => {
+		C_Settings.setValue("macroCachePath", macroCachePath);
+		C_FileSystem.removeFile(invalidMacroCachePath);
+	});
+
+	it("should automatically create an empty macro-cache.json file if none is present", () => {
+		assertFalse(C_FileSystem.fileExists(invalidMacroCachePath));
+
+		C_Settings.setValue("macroCachePath", invalidMacroCachePath);
+		C_Macro.restoreMacroCache();
+		assertTrue(C_FileSystem.fileExists(invalidMacroCachePath));
+	});
+});

--- a/Tests/run-renderer-tests.js
+++ b/Tests/run-renderer-tests.js
@@ -36,6 +36,7 @@ const testSuites = {
 		"API/C_WebAudio/isAudioAvailable.js",
 		"API/C_WebAudio/isAudioContextInitialized.js",
 	],
+	C_Macro: ["API/Macro/restoreMacroCache.js"],
 };
 
 for (const namespace in testSuites) {


### PR DESCRIPTION
It's not a very fancy solution; it just saves the current macro cache to disk when it's missing (which is empty on startup).

A better design may be needed in the future, but for now this'll have to do.