### PR TITLE
Add a global count alias for conveniently counting object keys

### DIFF
--- a/Config/eslint.json
+++ b/Config/eslint.json
@@ -120,6 +120,7 @@
 		"NOTICE": "writable",
 		"NODE": "writable",
 		"WARNING": "writable",
+		"count": "writable",
 		"dump": "writable",
 		"format": "readable",
 		"WEBCLIENT_ADDONS_DIR": "writable",

--- a/Core/Aliases.js
+++ b/Core/Aliases.js
@@ -19,6 +19,10 @@ function dump(...data) {
 	console.log(data);
 }
 
+function count(object) {
+	return Object.keys(object).length;
+}
+
 function printf(message, ...rest) {
 	// If we don't check the length, it will print an empty array when there are no parameters
 	rest.length > 0 ? console.log(message, ...rest) : console.log(message);


### PR DESCRIPTION
This isn't very performant, but still a useful shorthand for testing.