### PR TITLE
Add a standard way of accessing raw resource data

### DIFF
--- a/Core/APIs/C_Resources.js
+++ b/Core/APIs/C_Resources.js
@@ -32,7 +32,10 @@ C_Resources.load = function (resourceID, isCritical = false) {
 	DEBUG(format("Loading resource %s from disk", resourceID));
 
 	const resource = new Resource(resourceID, isCritical);
+
+	C_Profiling.startTimer("Disk I/O for resource " + resourceID);
 	const fileContents = C_FileSystem.readFileBinary(resourceID);
+	C_Profiling.endTimer("Disk I/O for resource " + resourceID);
 
 	resource.data = fileContents;
 	resource.state = Enum.RESOURCE_STATE_PENDING;

--- a/Core/APIs/C_Resources.js
+++ b/Core/APIs/C_Resources.js
@@ -76,8 +76,8 @@ C_Resources.updateCachedResource = function (resourceID, updatedResource) {
 	this.cachedResources[resourceID] = updatedResource;
 };
 
-	return Object.keys(this.cachedResources).length;
 C_Resources.getNumCachedResources = function () {
+	return count(this.cachedResources);
 };
 
 C_Resources.getResourceInfo = function (resourceID) {

--- a/Core/APIs/C_Resources.js
+++ b/Core/APIs/C_Resources.js
@@ -76,8 +76,8 @@ C_Resources.updateCachedResource = function (resourceID, updatedResource) {
 	this.cachedResources[resourceID] = updatedResource;
 };
 
-C_Resources.getCachedResourcesCount = function () {
 	return Object.keys(this.cachedResources).length;
+C_Resources.getNumCachedResources = function () {
 };
 
 C_Resources.getResourceInfo = function (resourceID) {

--- a/Core/Classes/Resource.js
+++ b/Core/Classes/Resource.js
@@ -27,6 +27,10 @@ class Resource {
 		new Uint8Array(newBuffer).set(new Uint8Array(this.data));
 		return newBuffer;
 	}
+	toJSON() {
+		// Should work for all data types; we can't assume it's already JSON (or even ArrayBuffer)
+		return JSON.parse(JSON.stringify(this.data));
+	}
 	rawGet() {
 		return this.data;
 	}

--- a/Core/Classes/Resource.js
+++ b/Core/Classes/Resource.js
@@ -27,4 +27,10 @@ class Resource {
 		new Uint8Array(newBuffer).set(new Uint8Array(this.data));
 		return newBuffer;
 	}
+	rawGet() {
+		return this.data;
+	}
+	rawSet(newData) {
+		this.data = newData;
+	}
 }

--- a/Tests/API/Resources/test-resource-builtin.js
+++ b/Tests/API/Resources/test-resource-builtin.js
@@ -1,0 +1,28 @@
+describe("Resource", () => {
+	describe("toJSON", () => {
+		it("should return a JSON representation of the raw resource data", () => {
+			const resourceData = { test: 42 };
+			const resource = new Resource("someID", false, resourceData);
+			assertEquals(resource.toJSON(), resourceData);
+		});
+	});
+
+	describe("rawGet", () => {
+		it("should return the raw resource data without modifying its format", () => {
+			const resourceData = { test: 42 };
+			const resource = new Resource("someID", false, resourceData);
+			assertEquals(resource.rawGet(), resourceData);
+		});
+	});
+
+	describe("rawSet", () => {
+		it("should set the raw resource data without modifying its format", () => {
+			const oldResourceData = { test: 123 };
+			const newResourceData = { test: 42 };
+			const resource = new Resource("someID", false, oldResourceData);
+			assertEquals(resource.rawGet(), oldResourceData);
+			resource.rawSet(newResourceData);
+			assertEquals(resource.rawGet(), newResourceData);
+		});
+	});
+});

--- a/Tests/run-renderer-tests.js
+++ b/Tests/run-renderer-tests.js
@@ -39,6 +39,7 @@ const testSuites = {
 		"API/C_WebAudio/isAudioContextInitialized.js",
 	],
 	C_Macro: ["API/Macro/restoreMacroCache.js"],
+	C_Resources: ["API/Resources/test-resource-builtin.js"],
 };
 
 for (const namespace in testSuites) {


### PR DESCRIPTION
It's a bit messy since this was just something I hacked in, but the Resources API needs a proper refactoring pass anyway.