### PR TITLE
Add a standardized API for checking if buffers have been consumed to the BinaryReader utility

### DIFF
--- a/Core/Builtins/BinaryReader.js
+++ b/Core/Builtins/BinaryReader.js
@@ -89,4 +89,8 @@ class BinaryReader {
 		this.offset = this.offset + 1;
 		return data;
 	}
+	hasReachedEOF() {
+		// This will help detect unexpected failure states (or missed data that wasn't accounted for somehow)
+		return this.offset === this.buffer.byteLength;
+	}
 }

--- a/Tests/API/Decoding/test-binary-reader.js
+++ b/Tests/API/Decoding/test-binary-reader.js
@@ -1,0 +1,17 @@
+describe("BinaryReader", () => {
+	describe("hasReachedEOF", () => {
+		it("should return false if the internal buffer still has unread bytes", () => {
+			const buffer = new ArrayBuffer(8);
+			const reader = new BinaryReader(buffer);
+			const whatever = reader.getUint32();
+			assertFalse(reader.hasReachedEOF());
+		});
+
+		it("should return true if the internal buffer has been consumed", () => {
+			const buffer = new ArrayBuffer(4);
+			const reader = new BinaryReader(buffer);
+			const whatever = reader.getUint32();
+			assertTrue(reader.hasReachedEOF());
+		});
+	});
+});

--- a/Tests/run-renderer-tests.js
+++ b/Tests/run-renderer-tests.js
@@ -9,7 +9,7 @@ const testSuites = {
 		"Builtins/Resource.js",
 		"Builtins/Validators.js",
 	],
-	C_Decoding: ["API/C_Decoding/BuiltinJsonDecoder.js"],
+	C_Decoding: ["API/Decoding/test-binary-reader.js", "API/C_Decoding/BuiltinJsonDecoder.js"],
 	C_LoadingScreen: ["API/C_LoadingScreen/test-async-task-scheduling.js"],
 	C_Math3D: ["API/Math3D/test-vector2d.js", "API/Math3D/test-vector3d.js", "API/Math3D/test-api-surface.js"],
 	C_Settings: [


### PR DESCRIPTION
Only one test case in this PR, to cover the new functionality. The rest will have to wait until I get around to it... some day.