### PR TITLE
Fix bitmap export for TerrainMaps

### DIFF
--- a/Core/Classes/TerrainMap.js
+++ b/Core/Classes/TerrainMap.js
@@ -27,7 +27,7 @@ class TerrainMap {
 		for (let tileID = 0; tileID < this.tiles.length; tileID++) {
 			const terrainTypeID = this.tiles[tileID] || 0;
 			const color = Color.TERRAIN_VISUALIZATION_COLORS[terrainTypeID];
-			pixelData.push(255, color.red, color.green, color.blue);
+			pixelData.push(color.red, color.green, color.blue, 255);
 		}
 
 		const bitmap = new Bitmap(pixelData, this.width, this.height);


### PR DESCRIPTION
The previous PNG library seems to have assumed a different pixel format, and I forgot to update this when swapping it out.

This doesn't have any tests, but I've opted to put that off until the Navigation API has been reworked.