### PR TITLE
Fix the Vector3D normalization logic

### DIFF
--- a/Core/API/Math3D/Vector3D.js
+++ b/Core/API/Math3D/Vector3D.js
@@ -7,7 +7,10 @@ class Vector3D {
 		this.z = z;
 	}
 	normalizeInPlace() {
-		this.coordinates.normalize();
+		const magnitude = Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z);
+		this.x *= 1 / magnitude;
+		this.y *= 1 / magnitude;
+		this.z *= 1 / magnitude;
 	}
 	clone() {
 		return new Vector3D(this.x, this.y, this.z);

--- a/Tests/API/Math3D/test-vector3d.js
+++ b/Tests/API/Math3D/test-vector3d.js
@@ -57,4 +57,13 @@ describe("Vector3D", () => {
 			assertEquals(Vector3D.ORIGIN, new Vector3D(0, 0, 0));
 		});
 	});
+
+	describe("normalizeInPlace", () => {
+		it("should normalize the vector to unit length", () => {
+			const vector = new Vector3D(3, 1, 2);
+			vector.normalizeInPlace();
+			const normalizedVector = new Vector3D(0.8017837257372732, 0.2672612419124244, 0.5345224838248488);
+			assertEquals(vector, normalizedVector);
+		});
+	});
 });


### PR DESCRIPTION
Looks like I forgot to update it during the refactoring process; the coordinates it's referring to no longer exist.